### PR TITLE
Initial API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018, City of Helsinki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/open_city_signups/settings.py
+++ b/open_city_signups/settings.py
@@ -72,6 +72,7 @@ INSTALLED_APPS = [
     'raven.contrib.django.raven_compat',
     'helusers',
     'rest_framework',
+    'django_filters',
 
     'users',
     'signups',
@@ -113,5 +114,8 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
     ),
 }

--- a/open_city_signups/settings.py
+++ b/open_city_signups/settings.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'raven.contrib.django.raven_compat',
     'helusers',
+    'rest_framework',
 
     'users',
     'signups',
@@ -103,3 +104,14 @@ TEMPLATES = [
 ]
 
 AUTH_USER_MODEL = 'users.User'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'helusers.oidc.ApiTokenAuthentication',
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100,
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+    ),
+}

--- a/open_city_signups/urls.py
+++ b/open_city_signups/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
+from rest_framework.documentation import include_docs_urls
 
 from signups.api import SignupTargetViewSet, SignupViewSet
 
@@ -11,4 +12,5 @@ router.register('signup_target', SignupTargetViewSet)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('v1/', include(router.urls)),
+    path('docs/', include_docs_urls(title='Open City sign-ups')),
 ]

--- a/open_city_signups/urls.py
+++ b/open_city_signups/urls.py
@@ -1,6 +1,14 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
+from rest_framework import routers
+
+from signups.api import SignupTargetViewSet, SignupViewSet
+
+router = routers.DefaultRouter()
+router.register('signup', SignupViewSet)
+router.register('signup_target', SignupTargetViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('v1/', include(router.urls)),
 ]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,3 +12,4 @@ pytest-cov
 pytest-django
 rope
 yapf
+factory_boy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,8 @@ autopep8==1.3.5
 backcall==0.1.0           # via ipython
 coverage==4.5.1           # via pytest-cov
 decorator==4.3.0          # via ipython, traitlets
+factory-boy==2.11.1
+faker==0.8.15             # via factory-boy
 flake8-polyfill==1.0.2    # via pep8-naming
 flake8==3.5.0
 importmagic==0.1.7
@@ -35,10 +37,12 @@ pygments==2.2.0           # via ipython
 pytest-cov==2.5.1
 pytest-django==3.2.1
 pytest==3.5.1
+python-dateutil==2.7.3    # via faker
 rope==0.10.7
 simplegeneric==0.8.1      # via ipython
-six==1.11.0               # via more-itertools, prompt-toolkit, pydocstyle, pytest, traitlets
+six==1.11.0               # via faker, more-itertools, prompt-toolkit, pydocstyle, pytest, python-dateutil, traitlets
 snowballstemmer==1.2.1    # via pydocstyle
+text-unidecode==1.2       # via faker
 traitlets==4.3.2          # via ipython
 wcwidth==0.1.7            # via prompt-toolkit
 yapf==0.21.0

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ psycopg2-binary
 raven
 django-helusers
 djangorestframework
+django-filter

--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,4 @@ raven
 django-helusers
 djangorestframework
 django-filter
+coreapi

--- a/requirements.in
+++ b/requirements.in
@@ -3,3 +3,4 @@ Django
 psycopg2-binary
 raven
 django-helusers
+djangorestframework

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
+coreapi==2.3.3
+coreschema==0.0.4         # via coreapi
 django-environ==0.4.4
 django-filter==1.1.0
 django-helusers==0.4.2
@@ -14,11 +16,15 @@ djangorestframework==3.8.2
 drf-oidc-auth==0.9        # via django-helusers
 future==0.16.0            # via pyjwkest
 idna==2.6                 # via requests
+itypes==1.1.0             # via coreapi
+jinja2==2.10              # via coreschema
+markupsafe==1.0           # via jinja2
 psycopg2-binary==2.7.4
 pycryptodomex==3.6.1      # via pyjwkest
 pyjwkest==1.4.0           # via drf-oidc-auth
 pytz==2018.4              # via django
 raven==6.8.0
-requests==2.18.4          # via django-helusers, pyjwkest
+requests==2.18.4          # via coreapi, django-helusers, pyjwkest
 six==1.11.0               # via django-environ, pyjwkest
+uritemplate==3.0.0        # via coreapi
 urllib3==1.22             # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chardet==3.0.4            # via requests
 django-environ==0.4.4
 django-helusers==0.4.2
 django==2.0.5
-djangorestframework==3.8.2  # via drf-oidc-auth
+djangorestframework==3.8.2
 drf-oidc-auth==0.9        # via django-helusers
 future==0.16.0            # via pyjwkest
 idna==2.6                 # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 django-environ==0.4.4
+django-filter==1.1.0
 django-helusers==0.4.2
 django==2.0.5
 djangorestframework==3.8.2

--- a/signups/api.py
+++ b/signups/api.py
@@ -1,4 +1,7 @@
+from django.utils.timezone import now
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import permissions, serializers, viewsets
+from rest_framework.exceptions import APIException, NotFound
 
 from .models import Signup, SignupTarget
 
@@ -25,6 +28,12 @@ class SignupSerializer(serializers.ModelSerializer):
         fields = ('id', 'target', 'created_at', 'cancelled_at')
 
 
+class SignupAlreadyExists(APIException):
+    status_code = 409
+    default_detail = _('The sign-up already exists.')
+    default_code = 'signup_already_exists'
+
+
 class SignupViewSet(viewsets.ModelViewSet):
     queryset = Signup.objects.select_related('target')
     serializer_class = SignupSerializer
@@ -32,3 +41,18 @@ class SignupViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return self.queryset.filter(user=self.request.user)
+
+    def perform_create(self, serializer):
+        queryset = Signup.objects.filter(user=self.request.user, target=serializer.validated_data['target'])
+
+        if queryset.exists():
+            raise SignupAlreadyExists()
+
+        serializer.save(user=self.request.user)
+
+    def perform_destroy(self, instance):
+        if instance.cancelled_at:
+            raise NotFound()
+
+        instance.cancelled_at = now()
+        instance.save(update_fields=('cancelled_at',))

--- a/signups/api.py
+++ b/signups/api.py
@@ -1,7 +1,7 @@
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from django_filters import rest_framework as filters
-from rest_framework import permissions, serializers, viewsets
+from rest_framework import mixins, permissions, serializers, viewsets
 from rest_framework.exceptions import APIException, NotFound
 
 from .models import Signup, SignupTarget
@@ -55,7 +55,8 @@ class SignupFilter(filters.FilterSet):
         return queryset
 
 
-class SignupViewSet(viewsets.ModelViewSet):
+class SignupViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin,
+                    viewsets.GenericViewSet):
     queryset = Signup.objects.select_related('target')
     serializer_class = SignupSerializer
     permission_classes = (permissions.IsAuthenticated,)

--- a/signups/api.py
+++ b/signups/api.py
@@ -91,7 +91,9 @@ class SignupViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.Cre
         return self.queryset.filter(user=self.request.user)
 
     def perform_create(self, serializer):
-        queryset = Signup.objects.filter(user=self.request.user, target=serializer.validated_data['target'])
+        queryset = Signup.objects.filter(
+            user=self.request.user, target=serializer.validated_data['target'], cancelled_at=None
+        )
 
         if queryset.exists():
             raise SignupAlreadyExists()

--- a/signups/api.py
+++ b/signups/api.py
@@ -1,0 +1,30 @@
+from rest_framework import serializers, viewsets
+
+from .models import Signup, SignupTarget
+
+
+class SignupTargetSerializer(serializers.ModelSerializer):
+    id = serializers.CharField(source='identifier')
+
+    class Meta:
+        model = SignupTarget
+        fields = ('id', 'name')
+
+
+class SignupTargetViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = SignupTarget.objects.all()
+    serializer_class = SignupTargetSerializer
+    lookup_field = 'identifier'
+
+
+class SignupSerializer(serializers.ModelSerializer):
+    target = serializers.SlugRelatedField(slug_field='identifier', queryset=SignupTarget.objects.all())
+
+    class Meta:
+        model = Signup
+        fields = ('id', 'target', 'created_at', 'cancelled_at')
+
+
+class SignupViewSet(viewsets.ModelViewSet):
+    queryset = Signup.objects.select_related('target')
+    serializer_class = SignupSerializer

--- a/signups/api.py
+++ b/signups/api.py
@@ -1,4 +1,4 @@
-from rest_framework import serializers, viewsets
+from rest_framework import permissions, serializers, viewsets
 
 from .models import Signup, SignupTarget
 
@@ -28,3 +28,7 @@ class SignupSerializer(serializers.ModelSerializer):
 class SignupViewSet(viewsets.ModelViewSet):
     queryset = Signup.objects.select_related('target')
     serializer_class = SignupSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get_queryset(self):
+        return self.queryset.filter(user=self.request.user)

--- a/signups/tests/conftest.py
+++ b/signups/tests/conftest.py
@@ -1,3 +1,4 @@
+import factory.random
 import pytest
 from rest_framework.test import APIClient
 
@@ -7,6 +8,11 @@ from signups.tests.factories import SignupFactory, SignupTargetFactory, UserFact
 @pytest.fixture(autouse=True)
 def no_more_mark_django_db(transactional_db):
     pass
+
+
+@pytest.fixture(autouse=True)
+def set_random_seed():
+    factory.random.reseed_random(777)
 
 
 @pytest.fixture

--- a/signups/tests/conftest.py
+++ b/signups/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+from rest_framework.test import APIClient
+
+from signups.tests.factories import SignupFactory, SignupTargetFactory, UserFactory
+
+
+@pytest.fixture(autouse=True)
+def no_more_mark_django_db(transactional_db):
+    pass
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user_api_client(user):
+    api_client = APIClient()
+    api_client.force_authenticate(user=user)
+    api_client.user = user
+    return api_client
+
+
+@pytest.fixture
+def user():
+    return UserFactory()
+
+
+@pytest.fixture
+def signup_target():
+    return SignupTargetFactory()
+
+
+@pytest.fixture
+def signup(signup_target, user):
+    return SignupFactory(user=user, target=signup_target)

--- a/signups/tests/factories.py
+++ b/signups/tests/factories.py
@@ -1,0 +1,33 @@
+import factory
+from django.contrib.auth import get_user_model
+from django.utils.text import slugify
+
+from signups.models import Signup, SignupTarget
+
+User = get_user_model()
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    uuid = factory.Faker('uuid4')
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    email = factory.Faker('email')
+
+    class Meta:
+        model = User
+
+
+class SignupTargetFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker('bs')
+    identifier = factory.LazyAttribute(lambda o: slugify(o.name))
+
+    class Meta:
+        model = SignupTarget
+
+
+class SignupFactory(factory.django.DjangoModelFactory):
+    user = factory.SubFactory(UserFactory)
+    target = factory.SubFactory(SignupTargetFactory)
+
+    class Meta:
+        model = Signup

--- a/signups/tests/test_migrations.py
+++ b/signups/tests/test_migrations.py
@@ -1,6 +1,0 @@
-import pytest
-
-
-@pytest.mark.django_db
-def test_migrations():
-    pass

--- a/signups/tests/test_signup_api.py
+++ b/signups/tests/test_signup_api.py
@@ -1,7 +1,9 @@
+from django.utils.timezone import now
 from rest_framework.reverse import reverse
 
-from signups.tests.utils import check_disallowed_methods, get
+from signups.models import Signup
 from signups.tests.factories import SignupFactory
+from signups.tests.utils import check_disallowed_methods, delete, get, post
 
 LIST_URL = reverse('signup-list')
 
@@ -45,3 +47,58 @@ def test_user_can_see_only_own_signups(user_api_client, signup):
     assert results[0]['id'] == signup.id
 
     get(user_api_client, get_detail_url(other_user_signup), status_code=404)
+
+
+def test_post_signup(user_api_client, signup_target):
+    assert Signup.objects.count() == 0
+
+    post(user_api_client, LIST_URL, {'target': signup_target.identifier})
+
+    assert Signup.objects.count() == 1
+    new_signup = Signup.objects.latest('id')
+    assert new_signup.user == user_api_client.user
+    assert new_signup.target == signup_target
+    assert new_signup.cancelled_at is None
+    assert new_signup.created_at
+
+
+def test_post_signup_nonexisting_target(user_api_client):
+    assert Signup.objects.count() == 0
+
+    data = post(user_api_client, LIST_URL, {'target': 'foobar'}, status_code=400)
+    assert 'target' in data
+
+
+def test_post_already_existing_signup(user_api_client, signup, signup_target):
+    assert Signup.objects.count() == 1
+
+    post(user_api_client, LIST_URL, {'target': signup_target.identifier}, status_code=409)
+
+    assert Signup.objects.count() == 1
+
+
+def test_delete_signup(user_api_client, signup):
+    assert Signup.objects.count() == 1
+    assert Signup.objects.filter(cancelled_at=None).count() == 1
+
+    delete(user_api_client, get_detail_url(signup))
+
+    assert Signup.objects.count() == 1
+    assert Signup.objects.filter(cancelled_at=None).count() == 0
+
+    signup.refresh_from_db()
+    assert signup.cancelled_at
+
+
+def test_cannot_delete_other_user_signup(user_api_client):
+    other_user_signup = SignupFactory()
+
+    delete(user_api_client, get_detail_url(other_user_signup), status_code=404)
+
+    Signup.objects.get(id=other_user_signup.id)
+
+
+def test_cannot_delete_already_cancelled_signup(user_api_client):
+    signup = SignupFactory(user=user_api_client.user, cancelled_at=now())
+
+    delete(user_api_client, get_detail_url(signup), status_code=404)

--- a/signups/tests/test_signup_api.py
+++ b/signups/tests/test_signup_api.py
@@ -1,0 +1,35 @@
+from rest_framework.reverse import reverse
+
+from signups.tests.utils import check_disallowed_methods, get
+
+LIST_URL = reverse('signup-list')
+
+
+def get_detail_url(obj):
+    return reverse('signup-detail', kwargs={'pk': obj.id})
+
+
+def check_signup_data(data, obj):
+    assert set(data.keys()) == {'id', 'target', 'created_at', 'cancelled_at'}
+
+    assert data['id'] == obj.id
+    assert data['target'] == obj.target.identifier
+
+
+def test_disallowed_methods(user_api_client, signup):
+    list_disallowed_methods = ('put', 'patch', 'delete')
+    check_disallowed_methods(user_api_client, LIST_URL, list_disallowed_methods)
+
+    detail_disallowed_methods = ('post',)
+    check_disallowed_methods(user_api_client, get_detail_url(signup), detail_disallowed_methods)
+
+
+def test_get_signup_list(user_api_client, signup):
+    data = get(user_api_client, LIST_URL)
+    signup_data = data['results'][0]
+    check_signup_data(signup_data, signup)
+
+
+def test_get_signup_detail(user_api_client, signup):
+    signup_data = get(user_api_client, get_detail_url(signup))
+    check_signup_data(signup_data, signup)

--- a/signups/tests/test_signup_api.py
+++ b/signups/tests/test_signup_api.py
@@ -24,7 +24,7 @@ def test_disallowed_methods(user_api_client, signup):
     list_disallowed_methods = ('put', 'patch', 'delete')
     check_disallowed_methods(user_api_client, LIST_URL, list_disallowed_methods)
 
-    detail_disallowed_methods = ('post',)
+    detail_disallowed_methods = ('post', 'put', 'patch')
     check_disallowed_methods(user_api_client, get_detail_url(signup), detail_disallowed_methods)
 
 

--- a/signups/tests/test_signup_api.py
+++ b/signups/tests/test_signup_api.py
@@ -20,6 +20,10 @@ def check_signup_data(data, obj):
     assert data['target'] == obj.target.identifier
 
 
+def test_unauthenticated_user_cannot_access(api_client):
+    get(api_client, LIST_URL, 401)
+
+
 def test_disallowed_methods(user_api_client, signup):
     list_disallowed_methods = ('put', 'patch', 'delete')
     check_disallowed_methods(user_api_client, LIST_URL, list_disallowed_methods)

--- a/signups/tests/test_signup_api.py
+++ b/signups/tests/test_signup_api.py
@@ -1,6 +1,7 @@
 from rest_framework.reverse import reverse
 
 from signups.tests.utils import check_disallowed_methods, get
+from signups.tests.factories import SignupFactory
 
 LIST_URL = reverse('signup-list')
 
@@ -33,3 +34,14 @@ def test_get_signup_list(user_api_client, signup):
 def test_get_signup_detail(user_api_client, signup):
     signup_data = get(user_api_client, get_detail_url(signup))
     check_signup_data(signup_data, signup)
+
+
+def test_user_can_see_only_own_signups(user_api_client, signup):
+    other_user_signup = SignupFactory()
+
+    data = get(user_api_client, LIST_URL)
+    results = data['results']
+    assert len(results) == 1
+    assert results[0]['id'] == signup.id
+
+    get(user_api_client, get_detail_url(other_user_signup), status_code=404)

--- a/signups/tests/test_signup_target_api.py
+++ b/signups/tests/test_signup_target_api.py
@@ -1,0 +1,34 @@
+from rest_framework.reverse import reverse
+
+from signups.tests.utils import check_disallowed_methods, get
+
+LIST_URL = reverse('signuptarget-list')
+
+
+def get_detail_url(obj):
+    return reverse('signuptarget-detail', kwargs={'identifier': obj.identifier})
+
+
+def check_signup_target_data(data, obj):
+    assert set(data.keys()) == {'id', 'name'}
+
+    assert data['id'] == obj.identifier
+    assert data['name'] == obj.name
+
+
+def test_disallowed_methods(user_api_client, signup_target):
+    disallowed_methods = ('post', 'put', 'patch', 'delete')
+    urls = (LIST_URL, get_detail_url(signup_target))
+
+    check_disallowed_methods(user_api_client, urls, disallowed_methods)
+
+
+def test_get_signup_target_list(api_client, signup_target):
+    data = get(api_client, LIST_URL)
+    signup_target_data = data['results'][0]
+    check_signup_target_data(signup_target_data, signup_target)
+
+
+def test_get_signup_target_detail(api_client, signup_target):
+    signup_target_data = get(api_client, get_detail_url(signup_target))
+    check_signup_target_data(signup_target_data, signup_target)

--- a/signups/tests/utils.py
+++ b/signups/tests/utils.py
@@ -1,0 +1,33 @@
+def get(api_client, url, status_code=200):
+    response = api_client.get(url)
+    assert response.status_code == status_code, 'Expected status code {} but got {} with data {}'.format(
+        status_code, response.status_code, response.data)
+    return response.data
+
+
+def post(api_client, url, data=None, status_code=201):
+    response = api_client.post(url, data)
+    assert response.status_code == status_code, 'Expected status code {} but got {} with data {}'.format(
+        status_code, response.status_code, response.data)
+    return response.data
+
+
+def delete(api_client, url, status_code=204):
+    response = api_client.delete(url)
+    assert response.status_code == status_code, 'Expected status code {} but got {} with data {}'.format(
+        status_code, response.status_code, response.data)
+    return response.data
+
+
+def check_disallowed_methods(api_client, urls, methods, status_code=405):
+    if isinstance(urls, str):
+        urls = (urls,)
+    if isinstance(methods, str):
+        methods = (methods,)
+
+    for url in urls:
+        for method in methods:
+            response = getattr(api_client, method)(url)
+            assert response.status_code == status_code, (
+                '%s %s expected %s, but got %s %s' % (method, url, status_code, response.status_code, response.data)
+            )


### PR DESCRIPTION
Added two API endpoints:

- `/v1/signup_target/` for listing available targets for sign-ups
- `/v1/signup/` for creating, listing, and cancelling own sign-ups

Sign-ups are created using http POST to `/v1/signup/` with payload field `target` containing the identifier of the target for the sign-up. Sign-ups can be cancelled by http DELETE to `/v1/signup/<id>/`.

By default, the signup endpoint returns only active sign-ups. Filter `include_cancelled` can be used to fetch also cancelled sign-ups. There is also filter `target=<identifier>` which returns sign-ups for the given target only.

Includes initial API docs in `/docs/`.

Tunnistamo based authentication is still WIP.

Added also license which was missing.

Closes #4 
