### PR TITLE
Rename Docker's DB container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - 5432:5432
         volumes:
             - postgres-data-volume:/var/lib/postgresql/data
-        container_name: postgres10-1
+        container_name: signups-db
 
     django:
         build: .


### PR DESCRIPTION
To prevent potential container naming conflicts, let's keep the
name a bit more specific to the project.

No refs