### PR TITLE
Fix template type field in notifications' admin

### DIFF
--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -13,7 +13,7 @@ class NotificationTemplateForm(TranslatableModelForm):
         qs = NotificationTemplate.objects.values_list('type', flat=True)
         if self.instance and self.instance.type:
             qs = qs.exclude(id=self.instance.id)
-        existing_types = set(qs)
+        existing_types = set(enum.value for enum in qs)
         choices = [x for x in self.fields['type'].choices if x[0] not in existing_types]
         self.fields['type'].choices = choices
 


### PR DESCRIPTION
We need to iterate over enums in queryset on this line in order
to get their values. This way "not in" check on the next line
will work correctly.